### PR TITLE
Use the standalone ChromeDriver binary

### DIFF
--- a/globals.js
+++ b/globals.js
@@ -1,0 +1,14 @@
+var chromedriver = require('chromedriver');
+
+module.exports = {
+  // Start the ChromeDriver running before running tests
+  before : function(done) {
+    chromedriver.start();
+    done();
+  },
+  // Stop the ChromeDriver after running tests
+  after : function(done) {
+    chromedriver.stop();
+    done();
+  }
+};

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -1,5 +1,3 @@
-var seleniumServer = require('selenium-server');
-
 module.exports = {
   "src_folders": ["tests"],
   "output_folder": "reports",
@@ -9,23 +7,15 @@ module.exports = {
   "globals_path": "",
 
   "selenium": {
-    "start_process": true,
-    "server_path": seleniumServer.path,
-    "host": "127.0.0.1",
-    "port": 4444
+    "start_process": false
   },
 
   "test_settings": {
     "default": {
       "launch_url": "http://dev.matthewroach.me/login/",
       "selenium_host": "localhost",
-      "selenium_port": 4444,
-      "pathname": "/wd/hub",
-      "silent": true,
-      "screenshots": {
-        "enabled": false,
-        "path": ""
-      },
+      "selenium_port": 9515,
+      "default_path_prefix": "",
       "desiredCapabilities": {
         "browserName": "chrome"
       }

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -1,4 +1,4 @@
-module.exports = {
+{
   "src_folders": ["tests"],
   "output_folder": "reports",
   "custom_commands_path": "",

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -4,7 +4,7 @@
   "custom_commands_path": "",
   "custom_assertions_path": "",
   "page_objects_path": "page-objects",
-  "globals_path": "",
+  "globals_path": "globals.js",
 
   "selenium": {
     "start_process": false

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "homepage": "https://github.com/matthewroach/nightwatch-demo#readme",
   "devDependencies": {
     "chromedriver": "^2.28.0",
-    "nightwatch": "^0.9.13",
-    "selenium-server": "^3.3.1"
+    "nightwatch": "^0.9.13"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -149,13 +149,7 @@ data-uri-to-buffer@0:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-0.0.4.tgz#46e13ab9da8e309745c8d01ce547213ebdb2fe3f"
 
-debug@2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
-  dependencies:
-    ms "0.7.2"
-
-debug@2.2.0:
+debug@2, debug@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
@@ -597,10 +591,6 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
-ms@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
-
 netmask@~1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
@@ -777,10 +767,6 @@ rimraf@^2.5.4:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
-
-selenium-server@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/selenium-server/-/selenium-server-3.3.1.tgz#0267380851601342d2bf0cbb89a57e893e8e7ba7"
 
 semver@~5.0.1:
   version "5.0.3"


### PR DESCRIPTION
This PR replaces the Selenium+WebDriver combination with a standalone ChromeDriver binary dependency, managed through NPM. No more Java required!