### PR TITLE
Add new custom assertions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,10 +8,6 @@
       "warn",
       2
     ],
-    "linebreak-style": [
-      "warn",
-      "unix"
-    ],
     "quotes": [
       "error",
       "single"

--- a/assertions/elementCount.js
+++ b/assertions/elementCount.js
@@ -14,7 +14,7 @@
  */
 
 var util = require('util');
-exports.assertion = function(selector, expected, msg = null) {
+exports.assertion = function(selector, expected, msg) {
 
   /**
    * The message which will be used in the test output and

--- a/assertions/elementCount.js
+++ b/assertions/elementCount.js
@@ -1,0 +1,61 @@
+/**
+ * Counts the number of children an element has in the DOM.
+ *
+ * ```
+ *    this.demoTest = function (client) {
+ *      browser.assert.titleContains("Nightwatch");
+ *    };
+ * ```
+ *
+ * @method title
+ * @param {string} expected The expected page title substring.
+ * @param {string} [message] Optional log message to display in the output. If missing, one is displayed by default.
+ * @api assertions
+ */
+
+var util = require('util');
+exports.assertion = function(selector, expected, msg = null) {
+
+  /**
+   * The message which will be used in the test output and
+   * inside the XML reports
+   * @type {string}
+   */
+  this.message = msg || util.format('Asserting that there are %d instance of <%s>', expected, selector);
+
+  /**
+   * A value to perform the assertion on. If a function is
+   * defined, its result will be used.
+   * @type {function|*}
+   */
+  this.expected = expected;
+
+  /**
+   * The method which performs the actual assertion. It is
+   * called with the result of the value method as the argument.
+   * @type {function}
+   */
+  this.pass = function(value) {
+    return value === expected;
+  };
+
+  /**
+   * The method which returns the value to be used on the
+   * assertion. It is called with the result of the command's
+   * callback as argument.
+   * @type {function}
+   */
+  this.value = function(result) {
+    return result.value.length;
+  };
+
+  /**
+   * Performs a protocol command/action and its result is
+   * passed to the value method via the callback argument.
+   * @type {function}
+   */
+  this.command = function(callback) {
+    return this.api.elements(this.client.locateStrategy, selector, callback);
+  };
+
+};

--- a/assertions/titleContains.js
+++ b/assertions/titleContains.js
@@ -16,17 +16,44 @@
 var util = require('util');
 exports.assertion = function(expected, msg) {
 
+  /**
+   * The message which will be used in the test output and
+   * inside the XML reports
+   * @type {string}
+   */
   this.message = msg || util.format('Testing if the page title contains "%s".', expected);
+
+  /**
+   * A value to perform the assertion on. If a function is
+   * defined, its result will be used.
+   * @type {function|*}
+   */
   this.expected = expected;
 
+  /**
+   * The method which performs the actual assertion. It is
+   * called with the result of the value method as the argument.
+   * @type {function}
+   */
   this.pass = function(value) {
     return value.indexOf(this.expected) > -1;
   };
 
+  /**
+   * The method which returns the value to be used on the
+   * assertion. It is called with the result of the command's
+   * callback as argument.
+   * @type {function}
+   */
   this.value = function(result) {
     return result.value;
   };
 
+  /**
+   * Performs a protocol command/action and its result is
+   * passed to the value method via the callback argument.
+   * @type {function}
+   */
   this.command = function(callback) {
     this.api.title(callback);
     return this;

--- a/assertions/titleContains.js
+++ b/assertions/titleContains.js
@@ -1,0 +1,35 @@
+/**
+ * Checks if the page title contains the given value.
+ *
+ * ```
+ *    this.demoTest = function (client) {
+ *      browser.assert.titleContains("Nightwatch");
+ *    };
+ * ```
+ *
+ * @method title
+ * @param {string} expected The expected page title substring.
+ * @param {string} [message] Optional log message to display in the output. If missing, one is displayed by default.
+ * @api assertions
+ */
+
+var util = require('util');
+exports.assertion = function(expected, msg) {
+
+  this.message = msg || util.format('Testing if the page title contains "%s".', expected);
+  this.expected = expected;
+
+  this.pass = function(value) {
+    return value.indexOf(this.expected) > -1;
+  };
+
+  this.value = function(result) {
+    return result.value;
+  };
+
+  this.command = function(callback) {
+    this.api.title(callback);
+    return this;
+  };
+
+};

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -2,7 +2,7 @@
   "src_folders": ["tests"],
   "output_folder": "reports",
   "custom_commands_path": "",
-  "custom_assertions_path": "",
+  "custom_assertions_path": "assertions",
   "page_objects_path": "objects",
   "globals_path": "nightwatch.globals.js",
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "A simple boilerplate setup for running automated end-to-end tests via Nightwatch.js",
   "scripts": {
-    "lint": "node node_modules/.bin/eslint .",
+    "lint": "node node_modules/eslint/bin/eslint .",
     "fix": "node node_modules/.bin/eslint . --fix",
     "test": "node node_modules/nightwatch/bin/nightwatch"
   },


### PR DESCRIPTION
This PR adds the two new custom assertions `elementCount()` and `titleContains()` and fixes a minor bug that caused ESLint to fail on Windows machines.